### PR TITLE
test(e2e): add smoke.basic.spec and run only [smoke] tests on main vi…

### DIFF
--- a/.github/workflows/smoke-e2e.yml
+++ b/.github/workflows/smoke-e2e.yml
@@ -160,6 +160,7 @@ jobs:
           echo "Using config: $CONFIG"
           # Kör hela sviten; preview-testet skippas automatiskt på smoke via TEST_CONTEXT
           npx playwright test \
+            --grep "\[smoke\]" \
             --project=${{ matrix.browser }} \
             --config="$CONFIG"
 

--- a/tests/e2e/smoke.basic.spec.ts
+++ b/tests/e2e/smoke.basic.spec.ts
@@ -1,19 +1,25 @@
-import { test, expect } from '@playwright/test';
-
-test.describe('[smoke] Smoke', () => {
-  test.beforeEach(async ({ page }) => {
-    await page.goto('/');
-  });
-
-  // ==== HOTFIX(TEST_CONTEXT): Kör bara i smoke (main), skippa i PR-previews ====
-  const __CTX = process.env.TEST_CONTEXT;
-  test.skip(__CTX === 'preview', 'smoke-only test (skippas på PR-previews).');
-  // ==== HOTFIX END ====
-
-  test('[smoke] Home renderar <main>', async ({ page }) => {
-    // Välj första "main" (undviker strict-mode kollision om fler finns)
-    const main = page.getByRole('main').first();
-    await main.scrollIntoViewIfNeeded();
-    await expect(main).toBeVisible({ timeout: 15000 });
-  });
-});
+*** Begin Patch
+*** Update File: tests/e2e/smoke.basic.spec.ts
++import { test, expect } from '@playwright/test';
++
++// ==== HOTFIX(TEST_CONTEXT) ================================================
++// Kör ENDAST denna spec i smoke-pipelinen (main). Defaulta till "preview"
++// om TEST_CONTEXT saknas → skippa i PR-previews och övriga okända miljöer.
++const __CTX = (process.env.TEST_CONTEXT ?? 'preview').toLowerCase();
++test.skip(__CTX !== 'smoke', 'Smoke-only spec – körs bara när TEST_CONTEXT=smoke.');
++// ==== HOTFIX END ==========================================================
++
++test.describe('[smoke] Smoke', () => {
++  test.beforeEach(async ({ page }) => {
++    await page.goto('/');
++  });
++
++  test('[smoke] Home renderar <main>', async ({ page }) => {
++    // Välj första "main" (undvik strict-mode kollision om flera finns)
++    const main = page.getByRole('main').first();
++    await main.scrollIntoViewIfNeeded();
++    await expect(main).toBeVisible({ timeout: 15000 });
++  });
++});
++
+*** End Patch

--- a/tests/e2e/smoke.basic.spec.ts
+++ b/tests/e2e/smoke.basic.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Smoke', () => {
+  test('[smoke] Home renderar <main>', async ({ page }) => {
+    const resp = await page.goto('/');
+    expect(resp && resp.ok(), 'GET / ska ge 2xx').toBeTruthy();
+
+    const main = page.locator('main');
+    await expect(main).toBeVisible();
+  });
+});


### PR DESCRIPTION
…a --grep in smoke-e2e.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the Playwright smoke spec to run only with TEST_CONTEXT=smoke, refactors the suite structure, and increases the visibility timeout.
> 
> - **E2E (Playwright)**:
>   - **`tests/e2e/smoke.basic.spec.ts`**:
>     - Gate execution to `TEST_CONTEXT=smoke` (lowercased); skip otherwise, replacing the prior preview-only skip.
>     - Restructure: use `test.describe('[smoke] Smoke')` and add `beforeEach` to navigate to `/`.
>     - Prefix test names with `[smoke]` and increase visibility timeout from `10000` to `15000`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b48ebe41f086726bcbf1bd5e047ff45e19e4f58d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->