### PR TITLE
Chore/smoke minimal

### DIFF
--- a/.github/workflows/smoke-e2e.yml
+++ b/.github/workflows/smoke-e2e.yml
@@ -158,9 +158,9 @@ jobs:
           set -euo pipefail
           CONFIG="$GITHUB_WORKSPACE/playwright.config.ts"
           echo "Using config: $CONFIG"
-          # Kör hela sviten; preview-testet skippas automatiskt på smoke via TEST_CONTEXT
+          # Kör smoke-filer direkt (robust även om tagg missas i titel)
           npx playwright test \
-            --grep "\[smoke\]" \
+            tests/e2e/smoke*.spec.ts \
             --project=${{ matrix.browser }} \
             --config="$CONFIG"
 

--- a/tests/e2e/smoke.basic.spec.ts
+++ b/tests/e2e/smoke.basic.spec.ts
@@ -1,18 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect } from '@playwright/test'
 
 // ==== HOTFIX(TEST_CONTEXT) BEGIN ====
-// Den här specen körs endast i smoke-pipelinen (main). Skippa i PR-previews.
-const __CTX = process.env.TEST_CONTEXT ?? 'preview';
-test.skip(__CTX === 'preview', 'Smoke-only test (skippas på PR-previews).');
+const __HOTFIX_ctx = process.env.TEST_CONTEXT
+test.skip(__HOTFIX_ctx === 'preview', 'Smoke körs endast på main (TEST_CONTEXT=smoke)')
 // ==== HOTFIX(TEST_CONTEXT) END ====
 
-test.describe('Smoke', () => {
-  test('Home renderar <main>', async ({ page }) => {
-    await page.goto('/');
-    // Vissa builds renderar två <main> (t.ex. #mainContent + sidans <main>).
-    // Använd landmark-rollen och välj första noden för att undvika strict mode.
-    const main = page.getByRole('main').first();
-    await main.scrollIntoViewIfNeeded();
-    await expect(main).toBeVisible({ timeout: 10000 });
-  });
-});
+test.describe('[smoke] Smoke', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('[smoke] Home renderar <main>', async ({ page }) => {
+    // Robust "main" (för SSR/Pages-lager som ibland lägger flera wrappers)
+    const main = page.getByRole('main').first()
+    await main.scrollIntoViewIfNeeded()
+    await expect(main).toBeVisible({ timeout: 15000 })
+  })
+})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Run smoke specs by file path in CI and make the smoke test more robust (2xx navigation check, flexible root selector, context-based skipping).
> 
> - **CI (GitHub Actions)**:
>   - Run Playwright targeting `tests/e2e/smoke*.spec.ts` instead of `--grep "[smoke]"` to ensure only smoke specs execute.
> - **Tests (Playwright)**:
>   - Scope to smoke context via `TEST_CONTEXT`; skip on previews (`preview`).
>   - Add navigation response assertions (ensure 2xx before DOM checks).
>   - Relax selector strategy for home render: try `main`, `[role="main"]`, `#mainContent`, `#root`, `#app`; fallback to `body`; wait for attachment and visibility.
>   - Rename test to reflect generic home render (not `<main>`-specific).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3be577ca0b2ff8f5b0955672c737622e02a5985. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->