### PR TITLE
ci: status-timestamp best-practice – switch to status before edits, w…

### DIFF
--- a/.github/workflows/status-timestamp.yml
+++ b/.github/workflows/status-timestamp.yml
@@ -13,35 +13,47 @@ on:
 
 jobs:
   update:
+    # Run when manually dispatched or when upstream workflows succeeded
     if: github.event_name == 'workflow_dispatch' || (github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout main
+      - name: Checkout repository (full history)
         uses: actions/checkout@v4
         with:
           ref: main
           persist-credentials: true
           fetch-depth: 0
 
-      - name: Update STATUS.md timestamp + write status.json
+      # IMPORTANT: Switch to 'status' branch BEFORE editing files
+      - name: Switch to 'status' branch (create if missing)
+        shell: bash
         run: |
           set -euo pipefail
-          TS="$(date -u +'%Y-%m-%d %H:%M UTC')"
-          sed -i "s|<!--STATUS_TS-->.*<!--/STATUS_TS-->|<!--STATUS_TS-->${TS}<!--/STATUS_TS-->|" STATUS.md
-          echo "{\"updated\":\"${TS}\"}" > status.json
-
-      - name: Switch to 'status' branch (create if missing)
-        run: |
           git fetch origin status || true
           if git ls-remote --exit-code --heads origin status >/dev/null 2>&1; then
             git checkout -B status origin/status
           else
+            # Create status branch from current ref (main)
             git checkout -B status
           fi
-      - name: Commit + push [skip ci]
+
+      - name: Update STATUS.md timestamp + write status.json (ISO8601Z)
+        shell: bash
         run: |
+          set -euo pipefail
+          TS="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+          # Update placeholder in STATUS.md
+          sed -i "s|<!--STATUS_TS-->.*<!--/STATUS_TS-->|<!--STATUS_TS-->${TS}<!--/STATUS_TS-->|" STATUS.md
+          # Create/overwrite status.json with ISO timestamp via jq
+          jq -n --arg ts "$TS" '{updated:$ts}' > status.json
+
+      - name: Commit + push to status [skip ci]
+        shell: bash
+        run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add STATUS.md status.json
-          git commit -m "docs: update STATUS timestamp + json [skip ci]" || echo "No changes"
+          git commit -m "docs: update STATUS timestamp (ISO) + json [skip ci]" || echo "No changes"
+          # Explicit ref push to status branch
           git push origin HEAD:status


### PR DESCRIPTION
…rite ISO8601Z via jq, explicit ref push