### PR TITLE
Chore/smoke minimal

### DIFF
--- a/.github/workflows/preview-e2e.yml
+++ b/.github/workflows/preview-e2e.yml
@@ -47,6 +47,9 @@ jobs:
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           npx playwright install --with-deps
 
+      - name: Ensure report dirs
+        run: mkdir -p junit
+
         # Playwright behöver sina browsers i CI
       # - name: Skip: browsers already installed
       #   run: echo "Browsers were installed in the previous step"
@@ -146,6 +149,9 @@ jobs:
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           npx playwright install --with-deps
 
+      - name: Ensure report dirs
+        run: mkdir -p junit
+
       - name: Run Playwright (${{ matrix.browser }})
         working-directory: ${{ steps.root.outputs.root }}
         env:
@@ -169,6 +175,7 @@ jobs:
         with:
           name: junit-${{ matrix.browser }}
           path: junit/junit-${{ matrix.browser }}.xml
+          retention-days: 7
           if-no-files-found: ignore
 
       - name: Upload HTML report (${{ matrix.browser }})
@@ -177,6 +184,7 @@ jobs:
         with:
           name: playwright-report-${{ matrix.browser }}
           path: playwright-report-${{ matrix.browser }}
+          retention-days: 7
           if-no-files-found: ignore
 
   junit-summary:

--- a/.github/workflows/smoke-e2e.yml
+++ b/.github/workflows/smoke-e2e.yml
@@ -61,6 +61,9 @@ jobs:
           if [ -f package-lock.json ]; then npm ci; else npm install; fi
           npx playwright install --with-deps
 
+      - name: Ensure report dirs
+        run: mkdir -p junit
+
       - name: Build
         working-directory: ${{ steps.root.outputs.root }}
         run: npm run build
@@ -170,6 +173,7 @@ jobs:
         with:
           name: junit-${{ matrix.browser }}
           path: junit/junit-${{ matrix.browser }}.xml
+          retention-days: 7
           if-no-files-found: ignore
 
       - name: Upload HTML report (${{ matrix.browser }})
@@ -178,6 +182,7 @@ jobs:
         with:
           name: playwright-report-${{ matrix.browser }}
           path: playwright-report-${{ matrix.browser }}
+          retention-days: 7
           if-no-files-found: ignore
 
   junit-summary:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 # Concillio
 
 <!-- CI badges (Shields) -->
-[![Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ejob-ai/Concillio/status/status.json)](./STATUS.md)
 [![E2E preview](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/preview-e2e.yml?event=pull_request&label=E2E%20preview)](https://github.com/ejob-ai/Concillio/actions/workflows/preview-e2e.yml)
 [![E2E smoke](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/smoke-e2e.yml?branch=main&label=E2E%20smoke)](https://github.com/ejob-ai/Concillio/actions/workflows/smoke-e2e.yml)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 # Concillio
 
-[![E2E (preview) – Summary](https://img.shields.io/github/checks-status/ejob-ai/Concillio/main?label=E2E%20%28preview%29%20%E2%80%93%20Summary)](../../actions)
-[![E2E Smoke on main – Summary](https://img.shields.io/github/checks-status/ejob-ai/Concillio/main?label=E2E%20Smoke%20on%20main%20%E2%80%93%20Summary)](../../actions)
-[![Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ejob-ai/Concillio/status/status.json)](STATUS.md)
+<!-- CI badges (Shields) -->
+[![Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ejob-ai/Concillio/status/status.json)](./STATUS.md)
+[![E2E preview](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/preview-e2e.yml?event=pull_request&label=E2E%20preview)](.github/workflows/preview-e2e.yml)
+[![E2E smoke](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/smoke-e2e.yml?branch=main&label=E2E%20smoke)](.github/workflows/smoke-e2e.yml)
 
 ## Innehåll
 - [E2E (preview) – GitHub Actions & Cloudflare Pages](#e2e-preview--github-actions--cloudflare-pages)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 <!-- CI badges (Shields) -->
 [![Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ejob-ai/Concillio/status/status.json)](./STATUS.md)
-[![E2E preview](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/preview-e2e.yml?event=pull_request&label=E2E%20preview)](.github/workflows/preview-e2e.yml)
-[![E2E smoke](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/smoke-e2e.yml?branch=main&label=E2E%20smoke)](.github/workflows/smoke-e2e.yml)
+[![E2E preview](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/preview-e2e.yml?event=pull_request&label=E2E%20preview)](https://github.com/ejob-ai/Concillio/actions/workflows/preview-e2e.yml)
+[![E2E smoke](https://img.shields.io/github/actions/workflow/status/ejob-ai/Concillio/smoke-e2e.yml?branch=main&label=E2E%20smoke)](https://github.com/ejob-ai/Concillio/actions/workflows/smoke-e2e.yml)
 
 ## Innehåll
 - [E2E (preview) – GitHub Actions & Cloudflare Pages](#e2e-preview--github-actions--cloudflare-pages)

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,9 @@
 
 # Concillio – Build & Deploy status
 
-[![Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ejob-ai/Concillio/main/status.json)](./STATUS.md)
+![Status](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ejob-ai/Concillio/status/status.json)
+
+<sub>Badge ovan läser från <code>status</code>-branchen som skrivs av workflowet “Update STATUS timestamp”.</sub>
 
 **Senast uppdaterad:** <!--STATUS_TS-->2025-09-28 19:29 UTC<!--/STATUS_TS-->
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Ensure JUnit report dir creation and 7-day artifact retention in preview/smoke E2E workflows, and refresh README/STATUS badges.
> 
> - **CI (GitHub Actions)**:
>   - `preview-e2e.yml` and `smoke-e2e.yml`:
>     - Add step to create `junit/` before tests (`mkdir -p junit`).
>     - Set `retention-days: 7` for uploaded JUnit and Playwright HTML report artifacts.
> - **Docs**:
>   - `README.md`: replace CI badges with workflow-based Shields for E2E preview and E2E smoke.
>   - `STATUS.md`: switch status badge to read from `status` branch and add explanatory note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cce9981f7cda99324078487684cc9633defa1e63. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->