### PR TITLE
ci(branch-protection): normalize API booleans for allow_* fields (han…

### DIFF
--- a/.github/workflows/set-branch-protection.yml
+++ b/.github/workflows/set-branch-protection.yml
@@ -120,9 +120,10 @@ jobs:
               end;
             def norm:
               {
-                allow_deletions,
-                allow_force_pushes,
-                block_creations,
+                # Normalize GitHub API booleans (sometimes objects {enabled:false})
+                allow_deletions: (.allow_deletions | if type=="boolean" then . else .enabled // false end),
+                allow_force_pushes: (.allow_force_pushes | if type=="boolean" then . else .enabled // false end),
+                block_creations: (.block_creations | if type=="boolean" then . else .enabled // false end),
                 bypass_pull_request_allowances: {
                   apps:  mapSlugs(arr(.bypass_pull_request_allowances.apps)),
                   teams: mapSlugs(arr(.bypass_pull_request_allowances.teams)),
@@ -169,9 +170,10 @@ jobs:
               end;
             def norm:
               {
-                allow_deletions,
-                allow_force_pushes,
-                block_creations,
+                # Normalize GitHub API booleans (sometimes objects {enabled:false})
+                allow_deletions: (.allow_deletions | if type=="boolean" then . else .enabled // false end),
+                allow_force_pushes: (.allow_force_pushes | if type=="boolean" then . else .enabled // false end),
+                block_creations: (.block_creations | if type=="boolean" then . else .enabled // false end),
                 bypass_pull_request_allowances: {
                   apps:  mapSlugs(arr(.bypass_pull_request_allowances.apps)),
                   teams: mapSlugs(arr(.bypass_pull_request_allowances.teams)),
@@ -279,9 +281,10 @@ jobs:
             def norm_rsc: if . == null then { strict: false, contexts: [] } else { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
             def norm:
               {
-                allow_deletions,
-                allow_force_pushes,
-                block_creations,
+                # Normalize GitHub API booleans (sometimes objects {enabled:false})
+                allow_deletions: (.allow_deletions | if type=="boolean" then . else .enabled // false end),
+                allow_force_pushes: (.allow_force_pushes | if type=="boolean" then . else .enabled // false end),
+                block_creations: (.block_creations | if type=="boolean" then . else .enabled // false end),
                 bypass_pull_request_allowances: {
                   apps:  mapSlugs(arr(.bypass_pull_request_allowances.apps)),
                   teams: mapSlugs(arr(.bypass_pull_request_allowances.teams)),
@@ -318,9 +321,10 @@ jobs:
             def norm_rsc: if . == null then { strict: false, contexts: [] } else { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
             def norm:
               {
-                allow_deletions,
-                allow_force_pushes,
-                block_creations,
+                # Normalize GitHub API booleans (sometimes objects {enabled:false})
+                allow_deletions: (.allow_deletions | if type=="boolean" then . else .enabled // false end),
+                allow_force_pushes: (.allow_force_pushes | if type=="boolean" then . else .enabled // false end),
+                block_creations: (.block_creations | if type=="boolean" then . else .enabled // false end),
                 bypass_pull_request_allowances: {
                   apps:  mapSlugs(arr(.bypass_pull_request_allowances.apps)),
                   teams: mapSlugs(arr(.bypass_pull_request_allowances.teams)),


### PR DESCRIPTION
…dle {enabled:false} objects)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Normalize `allow_deletions`, `allow_force_pushes`, and `block_creations` to booleans in jq canonicalization, handling API `{enabled:false}` objects.
> 
> - **Workflow** (`.github/workflows/set-branch-protection.yml`):
>   - Update jq `norm` to coerce GitHub API values for `allow_deletions`, `allow_force_pushes`, `block_creations` to booleans, supporting object form `{enabled:false}`.
>   - Apply the normalization in both "main" and "status" protection read-back/assert blocks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1632c0e137cb2e6e94d87bb2e80042cf8365bdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->