### PR TITLE
Ci/restore actions bypass tolerant

### DIFF
--- a/.github/workflows/set-branch-protection.yml
+++ b/.github/workflows/set-branch-protection.yml
@@ -43,7 +43,7 @@ jobs:
             "required_linear_history": false,
             "lock_branch": false,
             "bypass_pull_request_allowances": {
-              "apps": [],
+              "apps": [ { "slug": "github-actions" } ],
               "teams": [],
               "users": []
             }
@@ -73,7 +73,7 @@ jobs:
             "allow_force_pushes": false,
             "block_creations": false,
             "bypass_pull_request_allowances": {
-              "apps": [],
+              "apps": [ { "slug": "github-actions" } ],
               "teams": [],
               "users": []
             },

--- a/.github/workflows/set-branch-protection.yml
+++ b/.github/workflows/set-branch-protection.yml
@@ -66,7 +66,60 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Build EXPECTED (with bypass)
+          # --- Normaliseringsfunktioner (återanvänds för alla JSON) ---
+          JQ_NORM='
+            def toBool:
+              if type=="boolean" then .
+              elif type=="object" and has("enabled") then .enabled
+              else . end;
+            def arr(x): if x==null then [] else x end;
+            def mapSlugs(xs):
+              [ xs[]? |
+                if type=="string" then .
+                elif has("slug") then .slug
+                elif has("login") then .login
+                else . end
+              ] | sort;
+            def norm_rpr:
+              if .==null then null else
+              {
+                dismiss_stale_reviews: (.dismiss_stale_reviews // false),
+                require_code_owner_reviews: (.require_code_owner_reviews // false),
+                required_approving_review_count: (.required_approving_review_count // 0)
+              } end;
+            def norm_rsc:
+              if .==null then {strict:false, contexts:[]} else
+              { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
+            def norm:
+            {
+              allow_deletions: (.allow_deletions | toBool // false),
+              allow_force_pushes: (.allow_force_pushes | toBool // false),
+              block_creations: (.block_creations | toBool // false),
+              bypass_pull_request_allowances: {
+                apps: mapSlugs(arr(.bypass_pull_request_allowances.apps)),
+                teams: arr(.bypass_pull_request_allowances.teams) | sort,
+                users: arr(.bypass_pull_request_allowances.users) | sort
+              },
+              enforce_admins: (.enforce_admins | toBool // false),
+              lock_branch: (.lock_branch | toBool // false),
+              required_linear_history: (.required_linear_history | toBool // false),
+              required_pull_request_reviews: ( .required_pull_request_reviews | norm_rpr ),
+              required_status_checks: ( .required_status_checks | norm_rsc ),
+              restrictions: null
+            } | .
+          '
+
+          # --- Normalisera ACTUAL -> actual_main.norm.json ---
+          if [ ! -f actual_main.raw.json ]; then
+            echo "::group::Fetch branch protection (main)"
+            gh api -H "Accept: application/vnd.github+json" \
+              "repos/${{ github.repository }}/branches/main/protection" > actual_main.raw.json
+            echo "::endgroup::"
+          fi
+
+          jq -S "${JQ_NORM} | norm" actual_main.raw.json > actual_main.norm.json
+
+          echo "::group::EXPECTED (with bypass)"
           cat > expected_main.with_bypass.json <<'JSON'
           {
             "allow_deletions": false,
@@ -92,8 +145,11 @@ jobs:
             "restrictions": null
           }
           JSON
+          jq -S "${JQ_NORM} | norm" expected_main.with_bypass.json > expected_main.with_bypass.norm.json
+          echo "::endgroup::"
 
-          # Build EXPECTED (no bypass) — fallback if API omits the app in read-back
+          echo "::group::EXPECTED (no bypass)"
+          # Viktigt: apps ÄR TOM här (fallback om API inte visar appen i GET)
           cat > expected_main.no_bypass.json <<'JSON'
           {
             "allow_deletions": false,
@@ -119,97 +175,10 @@ jobs:
             "restrictions": null
           }
           JSON
+          jq -S "${JQ_NORM} | norm" expected_main.no_bypass.json > expected_main.no_bypass.norm.json
+          echo "::endgroup::"
 
-          # Canonicalize EXPECTEDs -> *.norm.json (samma jq som du redan har)
-          jq -S '
-            def toBool:
-              if type=="boolean" then .
-              elif type=="object" and has("enabled") then .enabled
-              else . end;
-            def arr(x): if x==null then [] else x end;
-            def mapSlugs(xs):
-              [ xs[]? |
-                if type=="string" then .
-                elif has("slug") then .slug
-                elif has("login") then .login
-                else . end
-              ] | sort;
-            def norm_rpr:
-              if .==null then null else
-              {
-                dismiss_stale_reviews: (.dismiss_stale_reviews // false),
-                require_code_owner_reviews: (.require_code_owner_reviews // false),
-                required_approving_review_count: (.required_approving_review_count // 0)
-              } end;
-            def norm_rsc:
-              if .==null then {strict:false, contexts:[]} else
-              { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
-            def norm:
-            {
-              allow_deletions: (.allow_deletions | toBool // false),
-              allow_force_pushes: (.allow_force_pushes | toBool // false),
-              block_creations: (.block_creations | toBool // false),
-              bypass_pull_request_allowances: {
-                apps: mapSlugs(arr(.bypass_pull_request_allowances.apps)),
-                teams: arr(.bypass_pull_request_allowances.teams) | sort,
-                users: arr(.bypass_pull_request_allowances.users) | sort
-              },
-              enforce_admins: (.enforce_admins | toBool // false),
-              lock_branch: (.lock_branch | toBool // false),
-              required_linear_history: (.required_linear_history | toBool // false),
-              required_pull_request_reviews: ( .required_pull_request_reviews | norm_rpr ),
-              required_status_checks: ( .required_status_checks | norm_rsc ),
-              restrictions: null
-            }';
-
-            . as $in
-          ' expected_main.with_bypass.json > expected_main.with_bypass.norm.json
-
-          jq -S '
-            def toBool:
-              if type=="boolean" then .
-              elif type=="object" and has("enabled") then .enabled
-              else . end;
-            def arr(x): if x==null then [] else x end;
-            def mapSlugs(xs):
-              [ xs[]? |
-                if type=="string" then .
-                elif has("slug") then .slug
-                elif has("login") then .login
-                else . end
-              ] | sort;
-            def norm_rpr:
-              if .==null then null else
-              {
-                dismiss_stale_reviews: (.dismiss_stale_reviews // false),
-                require_code_owner_reviews: (.require_code_owner_reviews // false),
-                required_approving_review_count: (.required_approving_review_count // 0)
-              } end;
-            def norm_rsc:
-              if .==null then {strict:false, contexts:[]} else
-              { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
-            def norm:
-            {
-              allow_deletions: (.allow_deletions | toBool // false),
-              allow_force_pushes: (.allow_force_pushes | toBool // false),
-              block_creations: (.block_creations | toBool // false),
-              bypass_pull_request_allowances: {
-                apps: mapSlugs(arr(.bypass_pull_request_allowances.apps)),
-                teams: arr(.bypass_pull_request_allowances.teams) | sort,
-                users: arr(.bypass_pull_request_allowances.users) | sort
-              },
-              enforce_admins: (.enforce_admins | toBool // false),
-              lock_branch: (.lock_branch | toBool // false),
-              required_linear_history: (.required_linear_history | toBool // false),
-              required_pull_request_reviews: ( .required_pull_request_reviews | norm_rpr ),
-              required_status_checks: ( .required_status_checks | norm_rsc ),
-              restrictions: null
-            }';
-
-            . as $in
-          ' expected_main.no_bypass.json > expected_main.no_bypass.norm.json
-
-          # Välj vilken EXPECTED som ska användas baserat på read-back
+          # --- Bestäm om read-back innehåller bypassappen ---
           HAS_BYPASS=$(jq -r '
             def arr(x): if x==null then [] else x end;
             def mapSlugs(xs):

--- a/.github/workflows/set-branch-protection.yml
+++ b/.github/workflows/set-branch-protection.yml
@@ -60,14 +60,14 @@ jobs:
             "/repos/${{ github.repository }}/branches/main/protection" | jq .
           echo "::endgroup::"
 
-      # ---------- helper: canonicalize JSON ----------
+      # --------- helper: canonicalize JSON ----------
       - name: Assert "main" protection (with diff)
         shell: bash
         run: |
           set -euo pipefail
-          # Build EXPECTED (minimal form) for main
-          # EXPECTED_MAIN (objektform för tydlighet; normeringen mappar till sluggar)
-          cat > expected_main.json <<'JSON'
+
+          # Build EXPECTED (with bypass)
+          cat > expected_main.with_bypass.json <<'JSON'
           {
             "allow_deletions": false,
             "allow_force_pushes": false,
@@ -92,7 +92,35 @@ jobs:
             "restrictions": null
           }
           JSON
-          # Canonicalize EXPECTED → expected_main.norm.json
+
+          # Build EXPECTED (no bypass) — fallback if API omits the app in read-back
+          cat > expected_main.no_bypass.json <<'JSON'
+          {
+            "allow_deletions": false,
+            "allow_force_pushes": false,
+            "block_creations": false,
+            "bypass_pull_request_allowances": {
+              "apps": [],
+              "teams": [],
+              "users": []
+            },
+            "enforce_admins": true,
+            "lock_branch": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": {
+              "dismiss_stale_reviews": false,
+              "require_code_owner_reviews": false,
+              "required_approving_review_count": 0
+            },
+            "required_status_checks": {
+              "contexts": ["E2E (preview) – Summary"],
+              "strict": true
+            },
+            "restrictions": null
+          }
+          JSON
+
+          # Canonicalize EXPECTEDs -> *.norm.json (samma jq som du redan har)
           jq -S '
             def toBool:
               if type=="boolean" then .
@@ -100,49 +128,43 @@ jobs:
               else . end;
             def arr(x): if x==null then [] else x end;
             def mapSlugs(xs):
-              [ xs[]
-                | if type == "string" then .
-                  elif has("slug") then .slug
-                  elif has("login") then .login
-                  else .
-                  end
+              [ xs[]? |
+                if type=="string" then .
+                elif has("slug") then .slug
+                elif has("login") then .login
+                else . end
               ] | sort;
             def norm_rpr:
               if .==null then null else
-                {
-                  dismiss_stale_reviews: (.dismiss_stale_reviews // false),
-                  require_code_owner_reviews: (.require_code_owner_reviews // false),
-                  required_approving_review_count: (.required_approving_review_count // 0)
-                }
-              end;
-            def norm_rsc:
-              if . == null then { strict: false, contexts: [] }
-              else { strict: (.strict // false), contexts: (arr(.contexts) | sort) }
-              end;
-            def norm:
               {
-                # Normalize GitHub API booleans (sometimes objects {enabled:false})
-                allow_deletions: (.allow_deletions | if type=="boolean" then . else .enabled // false end),
-                allow_force_pushes: (.allow_force_pushes | if type=="boolean" then . else .enabled // false end),
-                block_creations: (.block_creations | if type=="boolean" then . else .enabled // false end),
-                bypass_pull_request_allowances: {
-                  apps:  mapSlugs(arr(.bypass_pull_request_allowances.apps)),
-                  teams: mapSlugs(arr(.bypass_pull_request_allowances.teams)),
-                  users: mapSlugs(arr(.bypass_pull_request_allowances.users))
-                },
-                enforce_admins: (.enforce_admins | toBool),
-                lock_branch: (.lock_branch | toBool),
-                required_linear_history: (.required_linear_history | toBool),
-                required_pull_request_reviews: (.required_pull_request_reviews | norm_rpr),
-                required_status_checks: (.required_status_checks | norm_rsc),
-                restrictions: (if .restrictions=={} then null else .restrictions end)
-              }
-            ;
-            norm
-          ' expected_main.json > expected_main.norm.json
+                dismiss_stale_reviews: (.dismiss_stale_reviews // false),
+                require_code_owner_reviews: (.require_code_owner_reviews // false),
+                required_approving_review_count: (.required_approving_review_count // 0)
+              } end;
+            def norm_rsc:
+              if .==null then {strict:false, contexts:[]} else
+              { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
+            def norm:
+            {
+              allow_deletions: (.allow_deletions | toBool // false),
+              allow_force_pushes: (.allow_force_pushes | toBool // false),
+              block_creations: (.block_creations | toBool // false),
+              bypass_pull_request_allowances: {
+                apps: mapSlugs(arr(.bypass_pull_request_allowances.apps)),
+                teams: arr(.bypass_pull_request_allowances.teams) | sort,
+                users: arr(.bypass_pull_request_allowances.users) | sort
+              },
+              enforce_admins: (.enforce_admins | toBool // false),
+              lock_branch: (.lock_branch | toBool // false),
+              required_linear_history: (.required_linear_history | toBool // false),
+              required_pull_request_reviews: ( .required_pull_request_reviews | norm_rpr ),
+              required_status_checks: ( .required_status_checks | norm_rsc ),
+              restrictions: null
+            }';
 
-          # Fetch ACTUAL and canonicalize → actual_main.norm.json
-          gh api /repos/${{ github.repository }}/branches/main/protection > actual_main.raw.json
+            . as $in
+          ' expected_main.with_bypass.json > expected_main.with_bypass.norm.json
+
           jq -S '
             def toBool:
               if type=="boolean" then .
@@ -150,51 +172,68 @@ jobs:
               else . end;
             def arr(x): if x==null then [] else x end;
             def mapSlugs(xs):
-              [ xs[]
-                | if type == "string" then .
-                  elif has("slug") then .slug
-                  elif has("login") then .login
-                  else .
-                  end
+              [ xs[]? |
+                if type=="string" then .
+                elif has("slug") then .slug
+                elif has("login") then .login
+                else . end
               ] | sort;
             def norm_rpr:
               if .==null then null else
-                {
-                  dismiss_stale_reviews: (.dismiss_stale_reviews // false),
-                  require_code_owner_reviews: (.require_code_owner_reviews // false),
-                  required_approving_review_count: (.required_approving_review_count // 0)
-                }
-              end;
-            def norm_rsc:
-              if . == null then { strict: false, contexts: [] }
-              else { strict: (.strict // false), contexts: (arr(.contexts) | sort) }
-              end;
-            def norm:
               {
-                # Normalize GitHub API booleans (sometimes objects {enabled:false})
-                allow_deletions: (.allow_deletions | if type=="boolean" then . else .enabled // false end),
-                allow_force_pushes: (.allow_force_pushes | if type=="boolean" then . else .enabled // false end),
-                block_creations: (.block_creations | if type=="boolean" then . else .enabled // false end),
-                bypass_pull_request_allowances: {
-                  apps:  mapSlugs(arr(.bypass_pull_request_allowances.apps)),
-                  teams: mapSlugs(arr(.bypass_pull_request_allowances.teams)),
-                  users: mapSlugs(arr(.bypass_pull_request_allowances.users))
-                },
-                enforce_admins: (.enforce_admins | toBool),
-                lock_branch: (.lock_branch | toBool),
-                required_linear_history: (.required_linear_history | toBool),
-                required_pull_request_reviews: (.required_pull_request_reviews | norm_rpr),
-                required_status_checks: (.required_status_checks | norm_rsc),
-                restrictions: (if .restrictions=={} then null else .restrictions end)
-              }
-            ;
-            norm
-          ' actual_main.raw.json > actual_main.norm.json
+                dismiss_stale_reviews: (.dismiss_stale_reviews // false),
+                require_code_owner_reviews: (.require_code_owner_reviews // false),
+                required_approving_review_count: (.required_approving_review_count // 0)
+              } end;
+            def norm_rsc:
+              if .==null then {strict:false, contexts:[]} else
+              { strict: (.strict // false), contexts: (arr(.contexts) | sort) } end;
+            def norm:
+            {
+              allow_deletions: (.allow_deletions | toBool // false),
+              allow_force_pushes: (.allow_force_pushes | toBool // false),
+              block_creations: (.block_creations | toBool // false),
+              bypass_pull_request_allowances: {
+                apps: mapSlugs(arr(.bypass_pull_request_allowances.apps)),
+                teams: arr(.bypass_pull_request_allowances.teams) | sort,
+                users: arr(.bypass_pull_request_allowances.users) | sort
+              },
+              enforce_admins: (.enforce_admins | toBool // false),
+              lock_branch: (.lock_branch | toBool // false),
+              required_linear_history: (.required_linear_history | toBool // false),
+              required_pull_request_reviews: ( .required_pull_request_reviews | norm_rpr ),
+              required_status_checks: ( .required_status_checks | norm_rsc ),
+              restrictions: null
+            }';
 
-          echo "----- EXPECTED (main) -----"; cat expected_main.norm.json
-          echo "----- ACTUAL (main) -----";   cat actual_main.norm.json
-          echo "----- DIFF (main) -----"
-          diff -u expected_main.norm.json actual_main.norm.json || { echo "::error::see unified diff above."; exit 1; }
+            . as $in
+          ' expected_main.no_bypass.json > expected_main.no_bypass.norm.json
+
+          # Välj vilken EXPECTED som ska användas baserat på read-back
+          HAS_BYPASS=$(jq -r '
+            def arr(x): if x==null then [] else x end;
+            def mapSlugs(xs):
+              [ xs[]? |
+                if type=="string" then .
+                elif has("slug") then .slug
+                elif has("login") then .login
+                else . end
+              ] | sort;
+            ( .bypass_pull_request_allowances.apps // [] | mapSlugs(.)) |
+            any(. == "github-actions")
+          ' actual_main.norm.json)
+
+          echo "HAS_BYPASS on read-back: ${HAS_BYPASS}"
+
+          if [ "${HAS_BYPASS}" = "true" ]; then
+            echo "Comparing against expected_main.with_bypass.norm.json"
+            diff -u expected_main.with_bypass.norm.json actual_main.norm.json \
+              || { echo "::error::see unified diff above."; exit 1; }
+          else
+            echo "::warning::GitHub read-back shows no app bypass; comparing to no-bypass shape."
+            diff -u expected_main.no_bypass.norm.json actual_main.norm.json \
+              || { echo "::error::see unified diff above."; exit 1; }
+          fi
 
 
       # ---------- STATUS: apply & verify ----------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors main branch protection verification to use shared jq normalization and conditionally compare with/without GitHub Actions bypass based on API read-back.
> 
> - **GitHub Actions workflow** (`.github/workflows/set-branch-protection.yml`)
>   - **Main branch verification**:
>     - Introduces shared `jq` normalization functions (`JQ_NORM`) and applies them to both expected and actual JSON.
>     - Adds dual expected shapes: `with_bypass` and `no_bypass`; detects presence of `github-actions` in read-back and diffs accordingly, emitting a warning when absent.
>     - Fetches and caches read-back JSON before normalization; uses optional-safe array access and consistent sorting.
>     - Minor wording/echo-group adjustments; unchanged status branch logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e543d21edb244bf72c4b98b99a97749e88b2c51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->