### PR TITLE
ci: least-privilege permissions for auto-status-bump; guard status wo…

### DIFF
--- a/.github/workflows/auto-status-bump.yml
+++ b/.github/workflows/auto-status-bump.yml
@@ -1,5 +1,7 @@
 name: Auto STATUS bump on green smoke
 
+permissions: {}
+
 on:
   workflow_run:
     workflows: ["E2E Smoke on main"]

--- a/.github/workflows/status-timestamp.yml
+++ b/.github/workflows/status-timestamp.yml
@@ -20,9 +20,11 @@ jobs:
     # - repository_dispatch of type update-status-timestamp, or
     # - upstream workflows succeeded (preview/smoke)
     if: >
-      ${{ github.event_name == 'workflow_dispatch' ||
-          (github.event_name == 'repository_dispatch' && github.event.action == 'update-status-timestamp') ||
-          (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
+      ${{ github.event_name != 'pull_request' && (
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'repository_dispatch' && github.event.action == 'update-status-timestamp') ||
+            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+          ) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (full history)

--- a/.github/workflows/status-timestamp.yml
+++ b/.github/workflows/status-timestamp.yml
@@ -2,29 +2,15 @@ name: Update STATUS timestamp
 
 permissions:
   contents: write
-  actions: read
-  pull-requests: read
 
 on:
   workflow_dispatch: {}
   repository_dispatch:
     types: [update-status-timestamp]
-  workflow_run:
-    workflows: ["E2E (preview)", "E2E Smoke on main"]
-    types: [completed]
 
 jobs:
-  update:
-    # Run when:
-    # - manually dispatched, or
-    # - repository_dispatch of type update-status-timestamp, or
-    # - upstream workflows succeeded (preview/smoke)
-    if: >
-      ${{ github.event_name != 'pull_request' && (
-            github.event_name == 'workflow_dispatch' ||
-            (github.event_name == 'repository_dispatch' && github.event.action == 'update-status-timestamp') ||
-            (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
-          ) }}
+  bump:
+    # inga extra guards behövs – endast manuellt eller via repository_dispatch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository (full history)

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Det här repo:t använder en enkel trunk-based-strategi:
 
 Runbook: GitHub → Actions → configure branch protection (main & status) → Run workflow (workflow_dispatch) → verifiera grön diff i jobbloggen. Kräver ADMIN_TOKEN (fine-grained PAT med branch protection-rättighet).
 
+PAT-rotation: Roteras minst var 90:e dag. ADMIN_TOKEN måste ha minst följande rättigheter:
+- Repository contents: Read & write (för status-branch commits och repository_dispatch)
+- Branch protection/Administration: Read & write (för att sätta branchskydd via gh API)
+- Metadata: Read
+- Actions: Read (valfritt, för loggar)
+
 
 AI-driven rådslagstjänst med roller (Strategist, Futurist, Psychologist, Senior Advisor, Summarizer) och executive consensus.
 


### PR DESCRIPTION
…rkflow from PR events; docs: PAT rotation + ADMIN_TOKEN rights

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Tightens permissions/guards for STATUS bump automation, limits timestamp updates to manual/dispatch, and documents PAT rotation + required ADMIN_TOKEN rights.
> 
> - **CI/Workflows**:
>   - `/.github/workflows/auto-status-bump.yml`:
>     - Add least-privilege `permissions: {}`.
>     - Ensure bump dispatch only after successful non-PR `E2E Smoke on main` runs on `main` and same repository (`workflow_run` guards).
>   - `/.github/workflows/status-timestamp.yml`:
>     - Restrict execution to `workflow_dispatch` and `repository_dispatch` (`update-status-timestamp`), removing upstream `workflow_run` coupling and extra guards.
>     - Job renamed to `bump` (manual/dispatch only).
> - **Docs**:
>   - `README.md`: Add PAT rotation guidance and list required `ADMIN_TOKEN` permissions (contents write, branch protection/admin, metadata, optional actions).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3d3c23a6052532e1bd65fda2075ba595db83667e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->