### PR TITLE
chore(status): shields endpoint schema + safe worktree commit

### DIFF
--- a/.github/workflows/status-timestamp.yml
+++ b/.github/workflows/status-timestamp.yml
@@ -33,23 +33,36 @@ jobs:
             git checkout -B status
           fi
 
-      - name: Update STATUS.md timestamp + write status.json (ISO8601Z)
+      - name: Write TIMESTAMP, STATUS.md and Shields endpoint JSON
         shell: bash
         run: |
           set -euo pipefail
-          TS="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          # Update placeholder in STATUS.md
-          sed -i "s|<!--STATUS_TS-->.*<!--/STATUS_TS-->|<!--STATUS_TS-->${TS}<!--/STATUS_TS-->|" STATUS.md
-          # Create/overwrite status.json with ISO timestamp via jq
-          jq -n --arg ts "$TS" '{updated:$ts}' > status.json
+          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          mkdir -p status
 
-      - name: Commit + push to status [skip ci]
-        shell: bash
-        run: |
-          set -euo pipefail
+          # 1) Maskinläsbar tidsstämpel
+          echo "$TS" > status/TIMESTAMP
+
+          # 2) (valfri) status-sida för repo-visibility
+          cat > STATUS.md <<'MD'
+          # Concilio — Build & Deploy status
+          Denna sida uppdateras automatiskt av `.github/workflows/status-timestamp.yml` efter lyckade CI-körningar (eller vid manuell körning).
+          **Badge** läser från `status.json` på `status`-branchen.
+          MD
+
+          # 3) Shields endpoint enligt schemaVersion 1 (best practice)
+          jq -n --arg ts "$TS" '{
+            schemaVersion: 1,
+            label: "deploy",
+            message: ("ok (" + $ts + ")"),
+            color: "green",
+            cacheSeconds: 300
+          }' > status/status.json
+
+          # Git-commit på status-branchen (idempotent)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add STATUS.md status.json
-          git commit -m "docs: update STATUS timestamp (ISO) + json [skip ci]" || echo "No changes"
-          # Explicit ref push to status branch
-          git push origin HEAD:status
+          git checkout -B status
+          git add status/TIMESTAMP STATUS.md status/status.json
+          git commit -m "chore(status): update TIMESTAMP + shields endpoint" || echo "No changes to commit"
+          git push origin status

--- a/.github/workflows/status-timestamp.yml
+++ b/.github/workflows/status-timestamp.yml
@@ -59,10 +59,30 @@ jobs:
             cacheSeconds: 300
           }' > status/status.json
 
-          # Git-commit på status-branchen (idempotent)
+          # Git-commit till status-branchen (säkert, utan historik-reset)
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git checkout -B status
+
+          # Hämta ev. remote-branch info (utan att ändra working tree)
+          git fetch origin status:refs/remotes/origin/status || true
+
+          # Växla till status-branchen på ett säkert sätt
+          if git show-ref --verify --quiet refs/heads/status; then
+            # Lokal branch finns – uppdatera ff-only från remote om remote finns
+            git switch status
+            if git show-ref --verify --quiet refs/remotes/origin/status; then
+              git pull --ff-only origin status
+            fi
+          else
+            if git ls-remote --exit-code origin status >/dev/null 2>&1; then
+              # Skapa lokal tracking-branch från origin/status
+              git switch -c status --track origin/status
+            else
+              # Förstakörning: skapa ny lokal status-branch
+              git switch -c status
+            fi
+          fi
+
           git add status/TIMESTAMP STATUS.md status/status.json
           git commit -m "chore(status): update TIMESTAMP + shields endpoint" || echo "No changes to commit"
-          git push origin status
+          git push --set-upstream origin status

--- a/.github/workflows/status-timestamp.yml
+++ b/.github/workflows/status-timestamp.yml
@@ -59,30 +59,36 @@ jobs:
             cacheSeconds: 300
           }' > status/status.json
 
-          # Git-commit till status-branchen (säkert, utan historik-reset)
+          # --- Safe commit via worktree (no branch switching / no history reset) ---
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          # Hämta ev. remote-branch info (utan att ändra working tree)
-          git fetch origin status:refs/remotes/origin/status || true
+          # 0) Samla output i en separat katalog så vi inte rör working tree innan worktree finns
+          OUT="_status_out"
+          rm -rf "$OUT"; mkdir -p "$OUT/status"
+          cp -f status/TIMESTAMP "$OUT/status/TIMESTAMP"
+          cp -f STATUS.md "$OUT/STATUS.md"
+          cp -f status/status.json "$OUT/status/status.json"
 
-          # Växla till status-branchen på ett säkert sätt
-          if git show-ref --verify --quiet refs/heads/status; then
-            # Lokal branch finns – uppdatera ff-only från remote om remote finns
-            git switch status
-            if git show-ref --verify --quiet refs/remotes/origin/status; then
-              git pull --ff-only origin status
-            fi
+          # 1) Skapa/återanvänd worktree för status-branchen
+          WT="../status-worktree"
+          rm -rf "$WT"
+          if git ls-remote --exit-code origin status >/dev/null 2>&1; then
+            # Branch finns på remote → checkout den i en worktree
+            git worktree add -B status "$WT" origin/status
           else
-            if git ls-remote --exit-code origin status >/dev/null 2>&1; then
-              # Skapa lokal tracking-branch från origin/status
-              git switch -c status --track origin/status
-            else
-              # Förstakörning: skapa ny lokal status-branch
-              git switch -c status
-            fi
+            # Förstakörning: skapa ny branch i worktree
+            git worktree add -b status "$WT"
           fi
 
-          git add status/TIMESTAMP STATUS.md status/status.json
-          git commit -m "chore(status): update TIMESTAMP + shields endpoint" || echo "No changes to commit"
-          git push --set-upstream origin status
+          # 2) Kopiera in filer och committa
+          rsync -a --delete "$OUT/STATUS.md" "$OUT/status/" "$WT"/
+          pushd "$WT" >/dev/null
+            git add STATUS.md status/TIMESTAMP status/status.json
+            git commit -m "chore(status): update TIMESTAMP + shields endpoint" || echo "No changes to commit"
+            git push origin status
+          popd >/dev/null
+
+          # 3) Städa worktree
+          git worktree remove "$WT" --force
+          rm -rf "$OUT"


### PR DESCRIPTION
… write

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Workflow now writes status/TIMESTAMP, regenerates STATUS.md, creates schemaV1 Shields JSON at status/status.json, and commits to the status branch using a git worktree.
> 
> - **GitHub Actions workflow (`.github/workflows/status-timestamp.yml`)**:
>   - **Outputs**:
>     - Write ISO timestamp to `status/TIMESTAMP`.
>     - Overwrite `STATUS.md` with a brief status page.
>     - Create Shields endpoint JSON (`schemaVersion: 1`) at `status/status.json` with `label: "deploy"`, `message: "ok (TS)"`, `color: "green"`, `cacheSeconds: 300`.
>   - **Publishing**:
>     - Use a temporary output dir and `git worktree` to commit `STATUS.md`, `status/TIMESTAMP`, and `status/status.json` to the `status` branch, then clean up.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efdfc000b470df62ca90c8d7fa899362017d15cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->