### PR TITLE
ci(status): pin auto-status-bump to exact workflow content; condition…

### DIFF
--- a/.github/workflows/auto-status-bump.yml
+++ b/.github/workflows/auto-status-bump.yml
@@ -24,7 +24,7 @@ jobs:
           event-type: update-status-timestamp
           client-payload: '{"source":"auto-status-bump","run_id":"${{ github.run_id }}"}'
 
-      # Fallback körs ENDAST om repo-dispatch inte lyckades
+      # Kör fallback ENDAST om repo-dispatch misslyckades
       - name: Fallback dispatch via Actions API (workflow_dispatch)
         if: ${{ failure() || steps.repo_dispatch.outcome != 'success' }}
         uses: peter-evans/workflow-dispatch@v3


### PR DESCRIPTION
…al fallback only if repo-dispatch fails

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refines a Swedish comment in `.github/workflows/auto-status-bump.yml`; no functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd3664c79c8a0819aa267a9360d487c9789286d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->