### PR TITLE
test(e2e): add Playwright thank-you SSR/X-Robots-Tag preview test

### DIFF
--- a/tests/thank-you.spec.ts
+++ b/tests/thank-you.spec.ts
@@ -1,17 +1,50 @@
-import { describe, it, expect } from 'vitest'
+import { test, expect } from '@playwright/test';
 
-const BASE = process.env.BASE_URL
-const maybeIt = BASE ? it : it.skip
+test.describe('Thank-you page (preview)', () => {
+  test('SSR marker + X-Robots-Tag header', async ({ page }, testInfo) => {
+    // 1) Hitta mål-URL
+    const baseURL = (testInfo.project.use as any)?.baseURL as string | undefined;
+    const envURL =
+      process.env.PREVIEW_URL ||
+      process.env.BASE_URL ||
+      process.env.PLAYWRIGHT_BASE_URL ||
+      '';
 
-describe('/thank-you SSR', () => {
-  maybeIt('returns 200 and includes X-Robots-Tag: noindex', async () => {
-    const url = `${BASE}/thank-you?plan=starter&session_id=test`
-    const res = await fetch(url, { method: 'GET' })
-    expect(res.status).toBe(200)
-    const robots = (res.headers.get('x-robots-tag') || '').toLowerCase()
-    expect(robots).toContain('noindex')
-    expect(robots).toContain('nofollow')
-    const html = await res.text()
-    expect(html.toLowerCase()).toContain('tack')
-  })
-})
+    // Om baseURL finns i config använder vi relativ path (bästa vägen).
+    // Annars försöker vi bygga absolut URL från env.
+    let target = '/thank-you';
+    if (!baseURL) {
+      if (!envURL) test.skip(true, 'Ingen baseURL/PREVIEW_URL satt i CI – skippar testet.');
+      try {
+        target = new URL('/thank-you', envURL).toString();
+      } catch {
+        test.skip(true, 'Ogiltig PREVIEW_URL/BASE_URL – skippar testet.');
+      }
+    }
+
+    // 2) Navigera och fånga response + headers
+    const response = await page.goto(target, { waitUntil: 'domcontentloaded' });
+    expect(response, 'Kunde inte ladda sidan').toBeTruthy();
+    const status = response!.status();
+    const headers = response!.headers();
+    const location = (headers['location'] || headers['Location'] || '').toString();
+
+    // 3) Om Access-login-redirect → skippa (preflighten har redan verifierat det)
+    if ((status >= 300 && status < 400) && location.includes('/cdn-cgi/access/login')) {
+      test.skip(true, 'Preview kräver Access och saknar creds i denna körning – skippar SSR-asserts.');
+    }
+
+    // 4) Annars: asserta lyckad laddning + robots-header + SSR-markör
+    expect(status, `Oväntad HTTP-status: ${status}`).toBeLessThan(400);
+
+    const robots = (headers['x-robots-tag'] || headers['X-Robots-Tag'] || '').toString().toLowerCase();
+    expect(robots, 'X-Robots-Tag ska innehålla noindex,nofollow')
+      .toContain('noindex');
+    expect(robots).toContain('nofollow');
+
+    const main = page.locator('main.thankyou-page');
+    await expect(main, 'Hittar inte <main.thankyou-page>').toBeVisible();
+    // data-preview-validation ska finnas och likna YYYY-MM-DD
+    await expect(main).toHaveAttribute('data-preview-validation', /20\d{2}-\d{2}-\d{2}/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replaces the Vitest HTTP test with a Playwright e2e preview test that validates status, X-Robots-Tag, SSR marker, and safely handles Access redirects.
> 
> - **Tests**:
>   - **Migration to Playwright**: Rewrite `tests/thank-you.spec.ts` from Vitest/fetch to Playwright with preview-friendly baseURL/env resolution.
>   - **Navigation & response handling**: Use `page.goto` with null-response guard; capture status, headers, and `location`.
>   - **Assertions**:
>     - Status is 2xx/3xx; X-Robots-Tag includes `noindex` and `nofollow`.
>     - `<main.thankyou-page>` is visible and has `data-preview-validation` matching `YYYY-MM-DD`.
>   - **Conditional skip**: Skip when redirected to `/cdn-cgi/access/login` (Access-protected preview).
>   - **Removed**: Prior fetch-based SSR test and text-content check for "tack".
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad98551c95afe89c32a76cb69be05a6da936d40f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->