### PR TITLE
CI(main): add named job 'E2E (preview) – Summary' in preview workflow…

### DIFF
--- a/.github/workflows/preview-e2e.yml
+++ b/.github/workflows/preview-e2e.yml
@@ -187,18 +187,23 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-  junit-summary:
+  summary:
     name: E2E (preview) – Summary
-    needs: e2e
     runs-on: ubuntu-latest
     if: always()
+    needs:
+      - preview
+      - e2e
     steps:
-      - uses: actions/download-artifact@v4
-        with:
-          path: junit-merged
-      - uses: mikepenz/action-junit-report@v4
-        with:
-          report_paths: 'junit-merged/**/*.xml'
-          check_name: 'E2E (preview) – Summary'
-          fail_on_failure: false
-          include_passed: true
+      - name: Skriv enkel summering
+        shell: bash
+        run: |
+          echo "### E2E (preview) – sammanfattning" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Deploy:  ${{ needs.preview.result }}"  >> "$GITHUB_STEP_SUMMARY"
+          echo "- E2E job: ${{ needs.e2e.result }}"      >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Markera fail om matrisen inte var grön
+        if: needs.e2e.result != 'success'
+        run: |
+          echo "::error::E2E-matrisen misslyckades (result=${{ needs.e2e.result }})"
+          exit 1


### PR DESCRIPTION
…; always runs and fails if matrix failed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the JUnit report job with an always-on summary job that reports deploy/E2E results, depends on preview and e2e, and fails if the E2E matrix wasn’t green.
> 
> - **CI – `.github/workflows/preview-e2e.yml`**:
>   - **Summary job**: Rename `junit-summary` to `summary`; now depends on `preview` and `e2e`, always runs.
>     - Writes a brief job summary with `needs.preview.result` and `needs.e2e.result`.
>     - Fails the job if `needs.e2e.result != 'success'`.
>   - **Removed**: Artifact download and `mikepenz/action-junit-report` JUnit aggregation step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 333e861983d74bf6fb0ccc9f7c2682ca12b37b3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->